### PR TITLE
修复关键词包含特殊符号时搜索异常的问题

### DIFF
--- a/WGestures.App/AppSettings.cs
+++ b/WGestures.App/AppSettings.cs
@@ -32,10 +32,8 @@ namespace WGestures.App
 
         public static string UserDataDirectory
         {
-            get { return Application.LocalUserAppDataPath; }
+            get { return Application.ExecutablePath + @"\user_data"; }
         }
-
-
 
         public static string ConfigFilePath
         {

--- a/WGestures.App/AppSettings.cs
+++ b/WGestures.App/AppSettings.cs
@@ -32,7 +32,7 @@ namespace WGestures.App
 
         public static string UserDataDirectory
         {
-            get { return Application.ExecutablePath + @"\user_data"; }
+            get { return Application.StartupPath + @"\user_data"; }
         }
 
         public static string ConfigFilePath

--- a/WGestures.Core/Commands/Impl/WebSearchCommand.cs
+++ b/WGestures.Core/Commands/Impl/WebSearchCommand.cs
@@ -93,7 +93,7 @@ namespace WGestures.Core.Commands.Impl
 
                         string urlToOpen;
                         //如果是URL则打开，否则搜索
-                        if (Uri.IsWellFormedUriString(text, UriKind.Absolute))
+                        if (Uri.IsURL(text))
                         {
                             urlToOpen = text;
                         }
@@ -174,8 +174,6 @@ namespace WGestures.Core.Commands.Impl
                                 // Assume the registry value is set incorrectly, or some funky browser is used which currently is unknown.
                             }
                         }
-
-                       
                     }
                 }
             }
@@ -183,6 +181,8 @@ namespace WGestures.Core.Commands.Impl
             return "explorer.exe";
         }
 
-
+        private static bool IsURL(string text) {
+            return Uri.TryCreate(text, UriKind.Absolute, out Uri uriResult) && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+        }
     }
 }

--- a/WGestures.Core/Commands/Impl/WebSearchCommand.cs
+++ b/WGestures.Core/Commands/Impl/WebSearchCommand.cs
@@ -136,7 +136,7 @@ namespace WGestures.Core.Commands.Impl
 
         private string PopulateSearchEngingUrl(string param)
         {
-            return HttpUtility.UrlPathEncode(string.Format(SearchEngineUrl, param));
+            return string.Format(SearchEngineUrl, HttpUtility.UrlEncode(param));
         }
 
         public override string Description()


### PR DESCRIPTION
关键字包含冒号时，会导致搜索关键词失败